### PR TITLE
No thumbsdb

### DIFF
--- a/hashcheck.rb
+++ b/hashcheck.rb
@@ -174,6 +174,15 @@ TargetList.each.with_index do |targetlocation, index|
       end
     end
 
+    # Remove false positives for copies
+    copiedfiles.each do |copyline|
+      renamedfiles.each do |renameline|
+        if renameline.include?(copyline)
+          copiedfiles.delete(copyline)
+        end
+      end
+    end
+
     #Write csv
     csvpath = "#{OutputDirectory}/#{collection}_fixity_report_#{runtimeextension}.csv"
     CSV.open(csvpath, "ab") do |csv|

--- a/hashcheck.rb
+++ b/hashcheck.rb
@@ -99,17 +99,21 @@ TargetList.each.with_index do |targetlocation, index|
     oldmanifest = Array.new
     newmanifest = Array.new
     File.readlines("#{HashDirectory}/#{targetmanifest}").each do |line|
-      if OS.windows?
-        oldmanifest << line.gsub("\\", "/")
-      else
-        oldmanifest << line
+      if ! line.include?('Thumbs.db')
+        if OS.windows?
+          oldmanifest << line.gsub("\\", "/")
+        else
+          oldmanifest << line
+        end
       end
     end
     File.readlines("#{HashDirectory}/#{hashname}").each do |line|
-      if OS.windows?
-        newmanifest << line.gsub("\\", "/")
-      else
-        newmanifest << line
+      if ! line.include?('Thumbs.db')
+        if OS.windows?
+          newmanifest << line.gsub("\\", "/")
+        else
+          newmanifest << line
+        end
       end
     end
     neworchanged = (newmanifest - oldmanifest)


### PR DESCRIPTION
Tweak to filter out Thumbs.db and to avoid periodic double reporting of renamed files as copied files